### PR TITLE
Rework of private API in order to not expose private keys to the server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ If you want to enable API, create two more tables:
 
 `create table logs(status TEXT, name TEXT, user TEXT, time TEXT);`
 
-`status` is true or false, `name` is username of created account, `user` is name of API user (e.g dApp) (user from `apitokens` table).
+`status` is true or false, `name` is username of created account, `user` is name of API user (e.g dApp) (user from `apiTokens` table).
 
 `create table apitokens(token TEXT, user TEXT);`
 


### PR DESCRIPTION
I've reworked the private API in order to receive public keys instead of the password for account creation. The will increase security and password & keys can generated on the client side only.

A post request will expect this type of body:
````
{
    "name": "test-account",
    "publicKeys": {
        "owner": "STM8DX2RogwicpP6vssSE6zRjzbfKg1w51DkWu8R8KnnaLgjPUEpz",
        "active": "STM6UfZz3KfFAy1L5ozioR4Fbvut1b4TYqbNRkn6VemLr4jSXnV3D",
        "posting": "STM6sJNfb68XMYohUzTZ4npJi9ydpGbKfFQvY4UpeLCS3eUvnmby8",
        "memo": "STM5CUadUcebqf6jS6nNSWbrX8EJfYQ1CYb9S9ucqkntYZmPYJtGB"
    }
}
````

Maybe you wanna consider merging this change?